### PR TITLE
Upgrade firebase/php-jwt to version 6.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         "php": "^8.1|^8.2",
         "barryvdh/laravel-dompdf": "^2.0",
         "darkaonline/l5-swagger": "^8.5",
-        "firebase/php-jwt": "^5.2",
+        "firebase/php-jwt": "^6.0",
         "guzzlehttp/guzzle": "^7.2",
         "laravel/browser-kit-testing": "^7.0",
         "laravel/framework": "^10.10",


### PR DESCRIPTION
Firebase/PHP-JWT 5.2 has a known security vulnerability (code: PKSA-2kqm-ps5x-s4f5).